### PR TITLE
Load config at init

### DIFF
--- a/package/contents/code/main.js
+++ b/package/contents/code/main.js
@@ -172,6 +172,8 @@ var minimizeScaleEffect = {
         effect.configChanged.connect(minimizeScaleEffect.loadConfig);
         effects.windowMinimized.connect(minimizeScaleEffect.slotWindowMinimized);
         effects.windowUnminimized.connect(minimizeScaleEffect.slotWindowUnminimized);
+        
+        minimizeScaleEffect.loadConfig();
     }
 };
 


### PR DESCRIPTION
Fixes #1

Comparing with other but unrelated built-in KWin scripts that make use of configurable values (e.g. kwin4_effect_scale), it turns out that this effect is lacking a `loadConfig` call in the `minimizeScaleEffect.init` function, forcing the effect to use default parameters at first load but not when the effect settings are changed.